### PR TITLE
Handle string values in resolveRouteBinding()

### DIFF
--- a/src/Traits/OptimusEncodedRouteKey.php
+++ b/src/Traits/OptimusEncodedRouteKey.php
@@ -25,7 +25,11 @@ trait OptimusEncodedRouteKey
      */
     public function resolveRouteBinding($value)
     {
-        if (is_string($value) && !ctype_digit($value)) {
+        if (is_string($value) && ctype_digit($value)) {
+            $value = (int)$value;
+        }
+
+        if (!is_int($value)) {
             return null;
         }
 

--- a/src/Traits/OptimusEncodedRouteKey.php
+++ b/src/Traits/OptimusEncodedRouteKey.php
@@ -25,7 +25,9 @@ trait OptimusEncodedRouteKey
      */
     public function resolveRouteBinding($value)
     {
-        $value = intval($value);
+        if ( ! ctype_digit($value)) {
+            return null;
+        }
 
         $id = $this->getOptimus()->decode($value);
 

--- a/src/Traits/OptimusEncodedRouteKey.php
+++ b/src/Traits/OptimusEncodedRouteKey.php
@@ -25,6 +25,8 @@ trait OptimusEncodedRouteKey
      */
     public function resolveRouteBinding($value)
     {
+        $value = intval($value);
+
         $id = $this->getOptimus()->decode($value);
 
         return $this->where($this->getRouteKeyName(), '=', $id)->first();

--- a/src/Traits/OptimusEncodedRouteKey.php
+++ b/src/Traits/OptimusEncodedRouteKey.php
@@ -26,7 +26,7 @@ trait OptimusEncodedRouteKey
     public function resolveRouteBinding($value)
     {
         if (is_string($value) && ctype_digit($value)) {
-            $value = (int)$value;
+            $value = (int) $value;
         }
 
         if (!is_int($value)) {

--- a/src/Traits/OptimusEncodedRouteKey.php
+++ b/src/Traits/OptimusEncodedRouteKey.php
@@ -25,7 +25,7 @@ trait OptimusEncodedRouteKey
      */
     public function resolveRouteBinding($value)
     {
-        if ( ! ctype_digit($value)) {
+        if (!ctype_digit($value)) {
             return null;
         }
 

--- a/src/Traits/OptimusEncodedRouteKey.php
+++ b/src/Traits/OptimusEncodedRouteKey.php
@@ -25,7 +25,7 @@ trait OptimusEncodedRouteKey
      */
     public function resolveRouteBinding($value)
     {
-        if (!ctype_digit($value)) {
+        if (is_string($value) && !ctype_digit($value)) {
             return null;
         }
 

--- a/tests/Traits/OptimusEncodedRouteKeyTest.php
+++ b/tests/Traits/OptimusEncodedRouteKeyTest.php
@@ -19,6 +19,7 @@ use Cog\Tests\Laravel\Optimus\Stubs\Models\UserWithCustomOptimusConnection;
 use Cog\Tests\Laravel\Optimus\Stubs\Models\UserWithDefaultOptimusConnection;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\Route;
+use Jenssegers\Optimus\Optimus as JenssegersOptimus;
 
 class OptimusEncodedRouteKeyTest extends AbstractTestCase
 {
@@ -116,6 +117,19 @@ class OptimusEncodedRouteKeyTest extends AbstractTestCase
         $resolvedUser = $user->resolveRouteBinding("{$encodedRouteKey}-suffix-to-the-encoded-route-key");
 
         $this->assertNull($resolvedUser);
+    }
+
+    public function testExistingIntegerValuesBelow256AreResolved()
+    {
+        $user = $this->createUserWithDefaultOptimusConnection();
+
+        $optimus = $this->mock(JenssegersOptimus::class);
+        $optimus->shouldReceive('decode')->with(123)->andReturn($user->id);
+        Optimus::shouldReceive('connection')->andReturn($optimus);
+
+        $resolvedUser = $user->resolveRouteBinding(123);
+
+        $this->assertTrue($user->is($resolvedUser));
     }
 
     /**

--- a/tests/Traits/OptimusEncodedRouteKeyTest.php
+++ b/tests/Traits/OptimusEncodedRouteKeyTest.php
@@ -85,6 +85,14 @@ class OptimusEncodedRouteKeyTest extends AbstractTestCase
         $this->assertEquals($expectedUrl, $generatedUrl);
     }
 
+    public function testNonExistingIDsReturnNull()
+    {
+        $user = $this->createUserWithDefaultOptimusConnection();
+        $resolvedUser = $user->resolveRouteBinding(999);
+
+        $this->assertNull($resolvedUser);
+    }
+
     /**
      * Create a test user with default Optimus connection in the database.
      *

--- a/tests/Traits/OptimusEncodedRouteKeyTest.php
+++ b/tests/Traits/OptimusEncodedRouteKeyTest.php
@@ -119,6 +119,23 @@ class OptimusEncodedRouteKeyTest extends AbstractTestCase
         $this->assertNull($resolvedUser);
     }
 
+    public function testArrayValuesReturnNull()
+    {
+        $user = $this->createUserWithDefaultOptimusConnection();
+        $encodedRouteKey = $user->getRouteKey();
+        $resolvedUser = $user->resolveRouteBinding([$encodedRouteKey]);
+
+        $this->assertNull($resolvedUser);
+    }
+
+    public function testFloatValuesReturnNull()
+    {
+        $user = $this->createUserWithDefaultOptimusConnection();
+        $resolvedUser = $user->resolveRouteBinding(12.3);
+
+        $this->assertNull($resolvedUser);
+    }
+
     public function testExistingIntegerValuesBelow256AreResolved()
     {
         $user = $this->createUserWithDefaultOptimusConnection();

--- a/tests/Traits/OptimusEncodedRouteKeyTest.php
+++ b/tests/Traits/OptimusEncodedRouteKeyTest.php
@@ -109,13 +109,13 @@ class OptimusEncodedRouteKeyTest extends AbstractTestCase
         $this->assertNull($resolvedUser);
     }
 
-    public function testStringValuesMayContainingEncodedRouteKeys()
+    public function testStringValuesContainingEncodedRouteKeysReturnNull()
     {
         $user = $this->createUserWithDefaultOptimusConnection();
         $encodedRouteKey = $user->getRouteKey();
         $resolvedUser = $user->resolveRouteBinding("{$encodedRouteKey}-suffix-to-the-encoded-route-key");
 
-        $this->assertTrue($resolvedUser->is($user));
+        $this->assertNull($resolvedUser);
     }
 
     /**

--- a/tests/Traits/OptimusEncodedRouteKeyTest.php
+++ b/tests/Traits/OptimusEncodedRouteKeyTest.php
@@ -93,6 +93,31 @@ class OptimusEncodedRouteKeyTest extends AbstractTestCase
         $this->assertNull($resolvedUser);
     }
 
+    public function testStringValuesReturnNull()
+    {
+        $user = $this->createUserWithDefaultOptimusConnection();
+        $resolvedUser = $user->resolveRouteBinding('not-an-integer');
+
+        $this->assertNull($resolvedUser);
+    }
+
+    public function testStringValuesContainingIntegersReturnNull()
+    {
+        $user = $this->createUserWithDefaultOptimusConnection();
+        $resolvedUser = $user->resolveRouteBinding('1-not-just-an-integer');
+
+        $this->assertNull($resolvedUser);
+    }
+
+    public function testStringValuesMayContainingEncodedRouteKeys()
+    {
+        $user = $this->createUserWithDefaultOptimusConnection();
+        $encodedRouteKey = $user->getRouteKey();
+        $resolvedUser = $user->resolveRouteBinding("{$encodedRouteKey}-suffix-to-the-encoded-route-key");
+
+        $this->assertTrue($resolvedUser->is($user));
+    }
+
     /**
      * Create a test user with default Optimus connection in the database.
      *


### PR DESCRIPTION
## The Problem:

When entering a (faulty) URL that has a string instead of an encoded ID, an `InvalidArgumentException` was thrown instead of the expected `404` error:
<img width="397" alt="Schermafbeelding 2020-02-28 om 18 40 19" src="https://user-images.githubusercontent.com/3598622/75571649-e479d400-5a59-11ea-9e95-2e0311e9e9ca.png">

## The Fix:

In the `resolveRouteBinding()` method in the `OptimusEncodedRouteKey` trait, I convert the incoming slug to its `intval`. This will:

- convert string values to `0`,
- convert strings containing an integer to that integer (`999-hello` becomes `999`),

These values will not be found and result in the expected `404`.

## Question:

One last possibility is something you may or may not want:

When you enter a slug with an existing encoded ID and some text after it, like `12345-post-title`, this will be converted to the encoded ID `12345`. This WILL be decoded and found as you would expect.

If you don't want to allow these suffixes, additional checks should be made.

Tests are included.