### PR TITLE
Allow to use default route key name in custom router param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `cybercog/laravel-optimus` will be documented in this fil
 
 ## [Unreleased]
 
+## [3.7.0] - 2021-05-26
+
+### Added
+
+- ([#30]) Added custom route key support
+- ([#31]) Added default custom route key support
+
 ## [3.6.0] - 2020-12-31
 
 ### Added
@@ -87,7 +94,8 @@ All notable changes to `cybercog/laravel-optimus` will be documented in this fil
 
 Initial release
 
-[Unreleased]: https://github.com/cybercog/laravel-optimus/compare/3.6.0...master
+[Unreleased]: https://github.com/cybercog/laravel-optimus/compare/3.7.0...master
+[3.7.0]: https://github.com/cybercog/laravel-optimus/compare/3.6.0...3.7.0
 [3.6.0]: https://github.com/cybercog/laravel-optimus/compare/3.5.0...3.6.0
 [3.5.0]: https://github.com/cybercog/laravel-optimus/compare/3.4.2...3.5.0
 [3.4.2]: https://github.com/cybercog/laravel-optimus/compare/3.4.1...3.4.2
@@ -100,6 +108,8 @@ Initial release
 [2.1.0]: https://github.com/cybercog/laravel-optimus/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/cybercog/laravel-optimus/compare/1.0.0...2.0.0
 
+[#31]: https://github.com/cybercog/laravel-optimus/pull/31
+[#30]: https://github.com/cybercog/laravel-optimus/pull/30
 [#27]: https://github.com/cybercog/laravel-optimus/pull/27
 [#25]: https://github.com/cybercog/laravel-optimus/pull/25
 [#23]: https://github.com/cybercog/laravel-optimus/pull/23

--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ If you discover any security related issues, please email anton@komarev.com inst
 
 ## Contributors
 
-| <a href="https://github.com/antonkomarev">![@antonkomarev](https://avatars.githubusercontent.com/u/1849174?s=110)<br />Anton Komarev</a> | <a href="https://github.com/ivanvermeyen">![@ivanvermeyen](https://avatars.githubusercontent.com/u/3598622?s=110)<br />Ivan Vermeyen</a> | <a href="https://github.com/tur-nr">![@tur-nr](https://avatars.githubusercontent.com/u/817134?s=110)<br />Christopher Turner</a> |  
-| :---: | :---: | :---: |
+| <a href="https://github.com/antonkomarev">![@antonkomarev](https://avatars.githubusercontent.com/u/1849174?s=110)<br />Anton Komarev</a> | <a href="https://github.com/ivanvermeyen">![@ivanvermeyen](https://avatars.githubusercontent.com/u/3598622?s=110)<br />Ivan Vermeyen</a> | <a href="https://github.com/tur-nr">![@tur-nr](https://avatars.githubusercontent.com/u/817134?s=110)<br />Christopher Turner</a> | <a href="https://github.com/ahmedbally">![@ahmedbally](https://avatars.githubusercontent.com/u/20849424?s=110)<br />Ahmed Bally</a> |  
+| :---: | :---: | :---: | :---: |
 
 [Laravel Optimus contributors list](../../contributors)
 

--- a/src/Traits/OptimusEncodedRouteKey.php
+++ b/src/Traits/OptimusEncodedRouteKey.php
@@ -25,15 +25,19 @@ trait OptimusEncodedRouteKey
      */
     public function resolveRouteBinding($value, $field = null)
     {
+        if ($field === null) {
+            $field = $this->getRouteKeyName();
+        }
+
         if (is_string($value) && ctype_digit($value)) {
             $value = (int) $value;
         }
 
-        if (is_int($value) && is_null($field)) {
+        if (is_int($value) && $field === $this->getRouteKeyName()) {
             $value = $this->getOptimus()->decode($value);
         }
 
-        return $this->where($field ?? $this->getRouteKeyName(), $value)->first();
+        return $this->where($field, $value)->first();
     }
 
     /**

--- a/tests/Traits/OptimusEncodedRouteKeyTest.php
+++ b/tests/Traits/OptimusEncodedRouteKeyTest.php
@@ -69,6 +69,15 @@ class OptimusEncodedRouteKeyTest extends AbstractTestCase
         $this->assertEquals($user->id, $resolvedUser->id);
     }
 
+    public function testResolveModelWithEncodedKeyWithCustomIdKey(): void
+    {
+        $user = $this->createUserWithDefaultOptimusConnection();
+        $encodedId = $user->getRouteKey();
+        $resolvedUser = $user->resolveRouteBinding($encodedId, 'id');
+
+        $this->assertSame($user->id, $resolvedUser->id);
+    }
+
     public function testEncodedKeyIsUsedForRouteModelBinding(): void
     {
         $user = $this->createUserWithDefaultOptimusConnection();


### PR DESCRIPTION
Follow up #30

It will allow us to explicitly use route key too:

```php
Route::get('/posts/{id:encodedId}', function (Post $post) {
    return $post;
});
```