### PR TITLE
Add support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
     "require": {
         "php": "^7.1.3|^8.0",
         "graham-campbell/manager": "^4.0",
-        "illuminate/contracts": "^5.5|^6.0|^7.0|^8.0",
-        "illuminate/support": "^5.5|^6.0|^7.0|^8.0",
+        "illuminate/contracts": "^5.5|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0",
         "jenssegers/optimus": "^0.2.2"
     },
     "require-dev": {

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -21,11 +21,9 @@ abstract class AbstractTestCase extends AbstractPackageTestCase
     /**
      * Get the service provider class.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
-     *
      * @return string
      */
-    protected function getServiceProviderClass($app)
+    protected function getServiceProviderClass()
     {
         return OptimusServiceProvider::class;
     }


### PR DESCRIPTION
This will add support for Laravel 9.

To run the tests, I had to update a method signature in the AbstractTestCase.

There also seems to be a newer major version of jenssegers/optimus, but I did not update this.